### PR TITLE
Make panics more readable

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -67,6 +67,7 @@ working directory, named '<name of runtime>.(dmg|pkg)'.`,
 		}
 
 		if err := resp.Err(); err != nil {
+			fmt.Printf("\n\n")
 			panic(err)
 		}
 	},


### PR DESCRIPTION
This pull request improves the readability when there are network errors.

The `devimages-cdn.apple.com` hostname seems to have some issues at the moment, and am frequently getting `unexpected EOF` errors but they're not very readable. Unlike Xcode, at least the downloads are able to be resumed.

Before:
```
Downloading https://devimages-cdn.apple.com/downloads/xcode/simulators/com.apple.pkg.AppleTVSimulatorSDK15_0-15.0.1.1633542405.dmg...
   0% |                                            | (2.2 MB/2.7 GB) [2m16s:0s]panic: read tcp [2001:9e8:afa:1c01:21a6:6d80:595d:325]:52963->[2a01:b740:a26:f100::6]:443: read: operation timed out
```

After:
```
Downloading https://devimages-cdn.apple.com/downloads/xcode/simulators/com.apple.pkg.AppleTVSimulatorSDK15_0-15.0.1.1633542405.dmg...
   0% |                                            | (2.4 MB/2.7 GB) [2m15s:0s]

panic: read tcp [2001:9e8:afa:1c01:d4cb:369a:534d:54c5]:57315->[2a01:b740:a26:f100::6]:443: read: operation timed out
```